### PR TITLE
few bug fixes and concurrency refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,20 @@ lint:
 	$(GOLINT) ./...
 
 format:
-	$(GO)fmt -w .	
+	$(GO) fmt ./...
 
 macos:
-	GOOS=darwin GOARCH=amd64 $(GO) build -o alertcovid19 main.go
+	GOOS=darwin GOARCH=amd64 $(GO) build
 
 linux:
-	GOOS=linux GOARCH=amd64 $(GO) build -o alertcovid19 main.go
+	GOOS=linux GOARCH=amd64 $(GO) build -tags 'osusergo netgo static_build'
 	
 windows:
-	GOOS=windows GOARCH=amd64 $(GO) build -o alertcovid19.exe main.go
+	GOOS=windows GOARCH=amd64 $(GO) build
 
 zip:
 	zip alertcovid19_windows.zip alertcovid19.exe
 
 clean:
 	rm -f alertcovid19 alertcovid19.exe alertcovid19_windows.zip coverage.html
+

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,16 @@
 github.com/gen2brain/beeep v0.0.0-20200305193625-ff0f4a39397e h1:HCCLqGqQVEWSg6VnLpwkUM33ntwc7I/wQnH6C1F+dKY=
 github.com/gen2brain/beeep v0.0.0-20200305193625-ff0f4a39397e/go.mod h1:X4dJnVSeloSkLGKFiuwglrl9cJknASsBsJ1v5oOSf2k=
+github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c h1:16eHWuMGvCjSfgRJKqIzapE78onvvTbdi1rMkU00lZw=
 github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherwasm v1.1.0 h1:fA2uLoctU5+T3OhOn2vYP0DVT6pxc7xhTlBB1paATqQ=
 github.com/gopherjs/gopherwasm v1.1.0/go.mod h1:SkZ8z7CWBz5VXbhJel8TxCmAcsQqzgWGR/8nMhyhZSI=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
+github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG04SN9W+iWHCRyHqlVYILiSXziwk=
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2 h1:MZF6J7CV6s/h0HBkfqebrYfKCVEo5iN+wzE4QhV3Evo=
 gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2/go.mod h1:s1Sn2yZos05Qfs7NKt867Xe18emOmtsO3eAKbDaon0o=

--- a/main.go
+++ b/main.go
@@ -18,9 +18,9 @@ var (
 
 // LastValues ...
 type LastValues struct {
-	Confirmed uint `json"confirmed"`
-	Deaths    uint `json"deaths"`
-	Recovered uint `json"recovered"`
+	Confirmed uint `json:"confirmed"`
+	Deaths    uint `json:"deaths"`
+	Recovered uint `json:"recovered"`
 	UpdatedAt time.Time
 }
 

--- a/main.go
+++ b/main.go
@@ -86,9 +86,8 @@ func CompareInfos(currentValues LastValues) bool {
 }
 
 func routine(duration time.Duration) {
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
+	const timeout = time.Second * 2
+	for ctx, cancel := context.WithTimeout(context.Background(), timeout); ; cancel() {
 		currentValue, err := GetDataCOVID19(ctx)
 		if err != nil {
 			panic(err)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ type LastValues struct {
 	Confirmed uint `json:"confirmed"`
 	Deaths    uint `json:"deaths"`
 	Recovered uint `json:"recovered"`
-	UpdatedAt time.Time
+	// UpdatedAt time.Time XXX: move somewhere else
 }
 
 type response struct {
@@ -62,7 +62,6 @@ func GetDataCOVID19(ctx context.Context) (*LastValues, error) {
 			Confirmed: resp.Data.Confirmed,
 			Deaths:    resp.Data.Deaths,
 			Recovered: resp.Data.Recovered,
-			UpdatedAt: time.Now(),
 		}
 	}()
 	select {
@@ -75,16 +74,6 @@ func GetDataCOVID19(ctx context.Context) (*LastValues, error) {
 	}
 }
 
-// CompareInfos ...
-func CompareInfos(currentValues LastValues) bool {
-	if lastValues.Confirmed != currentValues.Confirmed ||
-		lastValues.Deaths != currentValues.Deaths ||
-		lastValues.Recovered != currentValues.Recovered {
-		return true
-	}
-	return false
-}
-
 func routine(duration time.Duration) {
 	const timeout = time.Second * 2
 	for ctx, cancel := context.WithTimeout(context.Background(), timeout); ; cancel() {
@@ -93,7 +82,7 @@ func routine(duration time.Duration) {
 			panic(err)
 		}
 
-		if CompareInfos(*currentValue) {
+		if lastValues == *currentValue {
 			err := beeep.Alert("COVID-19 Brazil", currentValue.String(), IMG)
 			if err != nil {
 				panic(err)

--- a/main.go
+++ b/main.go
@@ -107,6 +107,5 @@ func routine(duration time.Duration) {
 
 func main() {
 	flag.Parse()
-	lastValues = LastValues{}
 	routine(time.Duration(*timer))
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func GetDataCOVID19(ctx context.Context) (*LastValues, error) {
 		if err != nil {
 			errCh <- err
 		}
-		var resp *response
+		var resp response
 		err = json.Unmarshal(body, &resp)
 		if err != nil {
 			errCh <- err

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func GetDataCOVID19(ctx context.Context) (*LastValues, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	errCh := make(chan error, 1)
 	respCh := make(chan LastValues, 1)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -18,9 +18,9 @@ var (
 
 // LastValues ...
 type LastValues struct {
-	Confirmed uint `json:"confirmed"`
-	Deaths    uint `json:"deaths"`
-	Recovered uint `json:"recovered"`
+	Confirmed int `json:"confirmed"`
+	Deaths    int `json:"deaths"`
+	Recovered int `json:"recovered"`
 	// UpdatedAt time.Time XXX: move somewhere else
 }
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	timer = flag.Int64("timer", 3600, "This parameter define time in seconds to verify API ")
+	timer = flag.Duration("timer", time.Hour, "This parameter define time to verify API ")
 )
 
 // LastValues ...
@@ -102,7 +102,7 @@ func routine(duration time.Duration) {
 			lastValues = *currentValue
 		}
 		fmt.Println("opa time? ", duration, *timer)
-		time.Sleep(duration * time.Second)
+		time.Sleep(duration)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,43 +2,7 @@ package main
 
 import (
 	"testing"
-	"time"
 )
-
-func TestCompareInfos(t *testing.T) {
-	lastValues := &LastValues{
-		Confirmed: 1,
-		Deaths:    0,
-		Recovered: 0,
-		UpdatedAt: time.Now(),
-	}
-	type args struct {
-		currentValues LastValues
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "Test Compare Infos returns true",
-			args: args{currentValues: *lastValues},
-			want: true,
-		},
-		{
-			name: "Test Compare Infos returns false",
-			args: args{currentValues: LastValues{}},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := CompareInfos(tt.args.currentValues); got != tt.want {
-				t.Errorf("CompareInfos() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestLastValues_String(t *testing.T) {
 	type fields struct {

--- a/main_test.go
+++ b/main_test.go
@@ -5,32 +5,28 @@ import (
 )
 
 func TestLastValues_String(t *testing.T) {
-	type fields struct {
-		Confirmed uint
-		Deaths    uint
-		Recovered uint
-	}
-	tests := struct {
+	tests := []struct {
 		name   string
-		fields fields
+		fields LastValues
 		want   string
 	}{
-		name: "Test format message to show in the notification",
-		fields: fields{
-			Confirmed: 100,
-			Deaths:    7,
-			Recovered: 1,
+		{
+			name: "Test format message to show in the notification",
+			fields: LastValues{
+				Confirmed: 100,
+				Deaths:    7,
+				Recovered: 1,
+			},
+			want: "Confirmed: 100, Deaths: 7, Recovered: 1",
 		},
-		want: "Confirmed: 100, Deaths: 7, Recovered: 1",
 	}
-	t.Run(tests.name, func(t *testing.T) {
-		l := &LastValues{
-			Confirmed: tests.fields.Confirmed,
-			Deaths:    tests.fields.Deaths,
-			Recovered: tests.fields.Recovered,
-		}
-		if got := l.String(); got != tests.want {
-			t.Errorf("LastValues.String() = %v, want %v", got, tests.want)
-		}
-	})
+	for _, v := range tests {
+		v := v
+		t.Run(v.name, func(t *testing.T) {
+			t.Parallel()
+			if got := v.fields.String(); got != v.want {
+				t.Errorf("LastValues.String() = %v, want %v", got, v.want)
+			}
+		})
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ We are currently using this [COVID19-BRAZIL-API](https://covid19-brazil-api-docs
 ### Usage
 ```bash
 $ make <macos|linux|windows>  # if it's the window you can to run "make zip"
-$ ./alertcovid19 -timer=10    # 10 seconds
+$ ./alertcovid19 -t 10s    # 10 seconds
 $ make clean
 ```
 


### PR DESCRIPTION
1. fix badly formatted struct tag
2. context was never canceled, resources were never released and defer leads to indefinitely allocations
3. accept flag.Duration instead of flag.Int
4. make var resp *response of type response
  json.Unmarshal(&resp) // redundant convertion to type **response
5. Remove CompareInfo function in favor of plain '==' operator
6. Body reader wasn't being closed, thus RoundTripper might not reuse the connection safely, might lead to a FD leak.
7. makefile: remove redundant build flags and use static builds on linux
8. concurrency:
  fix goroutine leak: blocked sending in errCh or respCh if:
    * ReadAll fails and json.Unmarshal fail
    * ctx.Done() happens before errCh or respCh send
    * do not blockk in the slow operation (http.Get)
    * consume the input in the main loop instead of GetData